### PR TITLE
Add Display Key

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -4,6 +4,9 @@ version: 2.1
 
 description: |
   A Portshift vulneribilities scanner
+display:
+  home_url: https://www.portshift.io/
+  source_url: https://github.com/Portshift/CircleCI-Portshift-ORB
 examples:
   simple_build_and_scan:
     description: Scan a newly built docker image with Portshift vulneribilities scanner.


### PR DESCRIPTION
As a part of our best practices documentation: https://circleci.com/docs/2.0/orbs-best-practices/#orb-best-practices-guidelines
Provide a `source_url`, and if available, `home_url` via the display key.

https://circleci.com/docs/2.0/orb-author/#describing-your-orb

PS: Im not sure what it's saying I changed on line 148-150, but nothing was changed. It appears to be reacting to removing a newline automatically somehow.